### PR TITLE
Change single character value check to be more robust

### DIFF
--- a/h5deref/load.py
+++ b/h5deref/load.py
@@ -89,7 +89,7 @@ def load(fp, obj=None, **kwargs):  # noqa: C901
         if obj.shape is None:
             obj = None
         elif obj.attrs.get('MATLAB_class') == b'char':
-            if obj.shape[1] == 1:
+            if obj.shape == (1, 1):
                 obj = ''.join(map(chr, obj[()]))
             else:
                 obj = [''.join(map(chr, ll)) for ll in obj[()].T]


### PR DESCRIPTION
When checking for characters, the single character condition was looking at shape[1], whereas it should be shape[0]. I'm not sure if this was a workaround but to make sure, checking for shape == (1, 1) seemed the way to go.